### PR TITLE
Set default levelMax to ERROR

### DIFF
--- a/modules/rollbar/ModuleConfig.cfc
+++ b/modules/rollbar/ModuleConfig.cfc
@@ -36,7 +36,7 @@ component {
 		    "enableLogBoxAppender" = true,
 		    // Min/Max levels for appender
 		    "levelMin" = "FATAL",
-		    "levelMax" = "INFO",
+		    "levelMax" = "ERROR",
 		    // Enable/disable error logging
 		    "enableExceptionLogging" = true,
 		    // Data sanitization, scrub fields and headers, replaced with * at runtime


### PR DESCRIPTION
Prevents account limits from being reached, due to Info logging from 404's etc